### PR TITLE
Fix globs in work-processor-gse

### DIFF
--- a/work-processor-gse.py
+++ b/work-processor-gse.py
@@ -141,8 +141,10 @@ def build_work_to_chunk_map():
     print("Building work to chunk mapping...")
     
      # Get all individual work files and chunk files
-    work_files = glob.glob(os.path.join(INDIVIDUAL_WORKS_DIR, "*.{txt,md}"))
-    chunk_files = glob.glob(os.path.join(ORIGINAL_CHUNKS_DIR, "*.{txt,md}"))
+    work_files = glob.glob(os.path.join(INDIVIDUAL_WORKS_DIR, "*.txt")) + \
+                 glob.glob(os.path.join(INDIVIDUAL_WORKS_DIR, "*.md"))
+    chunk_files = glob.glob(os.path.join(ORIGINAL_CHUNKS_DIR, "*.txt")) + \
+                  glob.glob(os.path.join(ORIGINAL_CHUNKS_DIR, "*.md"))
     
     # Initialize the mapping
     mapping = {}


### PR DESCRIPTION
## Summary
- update file globbing in `build_work_to_chunk_map()` to search txt and md separately

## Testing
- `python -m py_compile work-processor-gse.py`

------
https://chatgpt.com/codex/tasks/task_e_6874db89c6988323ac1f173b601260bd