### PR TITLE
Fix file search bug in work mapping

### DIFF
--- a/enhanced_work_proccessor_b.py
+++ b/enhanced_work_proccessor_b.py
@@ -133,8 +133,14 @@ def build_work_to_chunk_map():
     print("Building work to chunk mapping...")
     
     # Get all individual work files and chunk files
-    work_files = glob.glob(os.path.join(INDIVIDUAL_WORKS_DIR, "*.{txt,md}"))
-    chunk_files = glob.glob(os.path.join(ORIGINAL_CHUNKS_DIR, "*.{txt,md}"))
+    work_files = (
+        glob.glob(os.path.join(INDIVIDUAL_WORKS_DIR, "*.txt"))
+        + glob.glob(os.path.join(INDIVIDUAL_WORKS_DIR, "*.md"))
+    )
+    chunk_files = (
+        glob.glob(os.path.join(ORIGINAL_CHUNKS_DIR, "*.txt"))
+        + glob.glob(os.path.join(ORIGINAL_CHUNKS_DIR, "*.md"))
+    )
     
     # Initialize the mapping
     mapping = {}

--- a/work-processor-gse.py
+++ b/work-processor-gse.py
@@ -140,9 +140,15 @@ def build_work_to_chunk_map():
     This is done by searching for text matches between work files and chunk files."""
     print("Building work to chunk mapping...")
     
-     # Get all individual work files and chunk files
-    work_files = glob.glob(os.path.join(INDIVIDUAL_WORKS_DIR, "*.{txt,md}"))
-    chunk_files = glob.glob(os.path.join(ORIGINAL_CHUNKS_DIR, "*.{txt,md}"))
+    # Get all individual work files and chunk files
+    work_files = (
+        glob.glob(os.path.join(INDIVIDUAL_WORKS_DIR, "*.txt"))
+        + glob.glob(os.path.join(INDIVIDUAL_WORKS_DIR, "*.md"))
+    )
+    chunk_files = (
+        glob.glob(os.path.join(ORIGINAL_CHUNKS_DIR, "*.txt"))
+        + glob.glob(os.path.join(ORIGINAL_CHUNKS_DIR, "*.md"))
+    )
     
     # Initialize the mapping
     mapping = {}


### PR DESCRIPTION
## Summary
- glob patterns used `{txt,md}` which Python's glob doesn't handle
- search for `.txt` and `.md` separately when building work-to-chunk map

## Testing
- `python -m py_compile batch_process.py layout-chunker.py work_chunk_splitter.py enhanced_work_proccessor_b.py upload_works_to_r2.py json2md_splitter.py work-processor-gse.py`

------
https://chatgpt.com/codex/tasks/task_e_6874d8d31cf483239906d278d5b96dca